### PR TITLE
refactor: adjusts logging for more flexibility 

### DIFF
--- a/components/Issuer/IndyWalletConnectionSetUp.vue
+++ b/components/Issuer/IndyWalletConnectionSetUp.vue
@@ -15,7 +15,7 @@ const generateQRCodeForConnection = () => {
     console.log(`invitation.....${invitationURL}`)
     invitationLink.value = invitationURL
     WalletConnectionID = connectionID
-    emit('addToLog', '[Issuer] Creating connection QRCode')
+    emit('addToLog', 'Creating connection QRCode', 'Issuer')
   })
 }
 

--- a/components/verifier/IndyWalletCredentialRequest.vue
+++ b/components/verifier/IndyWalletCredentialRequest.vue
@@ -10,7 +10,7 @@ const proofRequestID = ref('')
 const sendVCProofRequest = () => {
   sendProofRequest(connectionID).then((presentation_exchange_id) => {
     proofRequestID.value = presentation_exchange_id
-    emit('addToLog', '[Verifier] sent request for proof to wallet')
+    emit('addToLog', 'Sent request for proof', 'Verifier', 'Wallet')
   })
 }
 

--- a/composables/VerifiableCredential.ts
+++ b/composables/VerifiableCredential.ts
@@ -7,3 +7,9 @@ export interface DiplomaSchema {
   dateOfIssue: string;
 
 }
+
+export interface ActionLog {
+  source: string;
+  target?: string;
+  message: string;
+}

--- a/pages/issuer/issue.vue
+++ b/pages/issuer/issue.vue
@@ -14,17 +14,18 @@
       </ol>
     </nav>
   </div>
-  <div class="flex mt-14">
-    <div class="flex-1 p-4">
+  <div class="flex mt-14 shadow-md min-h-[500px] shadow-md rounded-xl bg-gray-50">
+    <div class="flex-1 p-4 mt-10 ml-10">
       <IssuerDiplomaCredentialForm v-if="step===Step.VC_FORM" @diploma-object-created="createCredentialData" @add-to-log="addToLog" />
-      <div v-if="step!==Step.VC_FORM" class="container mx-auto">
-        <p>Name: {{ CredentialData.signee }}</p>
-        <p>Document Number: {{ CredentialData.documentNumber }}</p>
-        <p>Subject: {{ CredentialData.subject }}</p>
-        <p>Degree: {{ CredentialData.degree }}</p>
-        <p>Date of issue: {{ CredentialData.dateOfIssue }}</p>
-        <p>Message: {{ CredentialData.body }}</p>
-        <br>
+      <div v-if="step!==Step.VC_FORM" class="container mx-auto max-w-4xl bg-white rounded-lg shadow-lg p-6 my-8">
+        <div class="space-y-2 font-medium text-gray-700">
+          <p>Name: <span class="font-normal">{{ CredentialData.signee }}</span></p>
+          <p>Document Number: <span class="font-normal">{{ CredentialData.documentNumber }}</span></p>
+          <p>Subject: <span class="font-normal">{{ CredentialData.subject }}</span></p>
+          <p>Degree: <span class="font-normal">{{ CredentialData.degree }}</span></p>
+          <p>Date of Issue: <span class="font-normal">{{ CredentialData.dateOfIssue }}</span></p>
+          <p>Message: <span class="font-normal">{{ CredentialData.body }}</span></p>
+        </div>
       </div>
       <IssuerIndyWalletConnectionSetUp v-if="step===Step.CONNECTION_SETUP" :connectionUserName="CredentialData.signee" @wallet-connection-established="SendCredentialToWallet"/>
       <div v-if="step===Step.SENDING_VC_TO_WALLET" class="container mx-auto text-center">
@@ -36,7 +37,7 @@
         <p v-if="step===Step.DONE" class="text-center"> Credential Successfully Sent to wallet</p>
       </div>
     </div>
-    <div class="w-72 bg-gray-100 p-6 bg-gray-300 -mt-8">
+    <div class="w-72 bg-gray-100 p-6 bg-gray-300 -mt-10 rounded-md shadow-lg">
       <h2 class="text-xl font-semibold">Updates</h2>
       <ol class="list-decimal">
         <li v-for="message in logMessages">

--- a/pages/verifier/verify.vue
+++ b/pages/verifier/verify.vue
@@ -14,8 +14,8 @@
       </ol>
     </nav>
   </div>
-  <div class="flex mt-14">
-    <div class="flex-1">
+  <div class="flex mt-14 shadow-md min-h-[500px] shadow-md rounded-xl bg-gray-50">
+    <div class="flex-1 mt-10 ml-10">
       <div v-if="step===Step.CONNECTION_SETUP" class="flex items-center justify-center gap-x-6">
         <button type="button" @click="generateQRCodeForConnection" class="rounded-md bg-indigo-600 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600">Generate Verification QR Code!</button>
         <div v-if="invitationLink" class="flex-auto text-center">
@@ -26,13 +26,16 @@
       </div>
       <div v-if="step===Step.REQUESTING_CREDENTIALS">Requesting Credentials...</div>
       <VerifierIndyWalletCredentialRequest v-if="step===Step.REQUESTING_CREDENTIALS" :connectionID="WalletConnectionID" @verifiable-credential-proof="displayProof"/>
-      <div v-if="step===Step.DONE" class="flex center justify-center gap-x-6">
+      <div v-if="step===Step.DONE" class="container mx-auto max-w-4xl bg-white rounded-lg shadow-lg p-6 my-8">
+        <h2 class="text-2xl font-semibold mb-4 text-gray-800">Credential Information</h2>
+        <div class="space-y-2 font-medium text-gray-700">
           <p>Subject: {{ proofRequestSubject }}</p>
           <p>Degree: {{ proofRequestDegree }}</p>
           <p>Document Number: {{ proofRequestDocumentNumber }}</p>
+        </div>
       </div>
     </div>
-    <div class="w-72 bg-gray-100 p-6 bg-gray-300 -mt-8">
+    <div class="w-72 bg-gray-100 p-6 bg-gray-300 -mt-10 rounded-md shadow-lg">
       <h2 class="text-xl font-semibold">Updates</h2>
       <ol class="list-decimal">
         <li v-for="message in logMessages">


### PR DESCRIPTION
I was refactoring the code to add icons instead of the wallet/issuer/verifier in the logs, but even with all this refactoring, it still was a bit complicated to do it at the end. However, this refactor might still be useful (if not too complicated).

I can also add the icons later if we needed.

I also used here `[source to destination] message` format for the logs as suggested by Linus.